### PR TITLE
fix: Prevent overwriting of Python environment PATH by lazy loading pyenv.

### DIFF
--- a/pyenv-lazy.plugin.zsh
+++ b/pyenv-lazy.plugin.zsh
@@ -6,7 +6,9 @@ fi
 
 # Lazy load pyenv
 if type pyenv > /dev/null; then
-    export PATH="${PYENV_ROOT}/bin:${PYENV_ROOT}/shims:${PATH}"
+    if [[ ! -n "${VIRTUAL_ENV}" ]]; then
+        export PATH="${PYENV_ROOT}/bin:${PYENV_ROOT}/shims:${PATH}"
+    fi
     function pyenv() {
         unset -f pyenv
         eval "$(command pyenv init -)"


### PR DESCRIPTION
The purpose is preventing the PATH for the virtual environment's Python from being overridden by the one pointed to by pyenv, which can happen when the shell is restarted while inside the virtual environment using tools such as Poetry.